### PR TITLE
Give the instantCommand running as the default command for the Elevation subsystem a name.

### DIFF
--- a/roborio-src/robotcontainer.py
+++ b/roborio-src/robotcontainer.py
@@ -85,7 +85,9 @@ class RobotContainer:
 
         # Keep elevation at home/load, when it's not doing anything else
         self.elevationSubsystem.setDefaultCommand(
-            self.elevationSubsystem.moveToLoadPositionCommand()
+            self.elevationSubsystem.moveToLoadPositionCommand().withName(
+                "Moving to load position."
+            )
         )
 
         # Chooser


### PR DESCRIPTION
Fixes #190